### PR TITLE
mbf_costmap_nav/mbf_abstract_nav: Allow to pass nodehandles to navigation_server

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -123,12 +123,14 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
     /**
      * @brief Constructor, reads all parameters and initializes all action servers and creates the plugin instances.
      *        Parameters are the concrete implementations of the abstract classes.
+     * @param nh Public node handle.
+     * @param nhp Private node handle.
      * @param tf_listener_ptr shared pointer to the common TransformListener buffering transformations
      * @param planning_ptr shared pointer to an object of the concrete derived implementation of the AbstractPlannerExecution
      * @param moving_ptr shared pointer to an object of the concrete derived implementation of the AbstractControllerExecution
      * @param recovery_ptr shared pointer to an object of the concrete derived implementation of the AbstractRecoveryExecution
      */
-    AbstractNavigationServer(const TFPtr &tf_listener_ptr);
+    AbstractNavigationServer(const ros::NodeHandle &nh, const ros::NodeHandle &nhp, const TFPtr &tf_listener_ptr);
     /**
      * @brief Destructor
      */

--- a/mbf_abstract_nav/src/abstract_navigation_server.cpp
+++ b/mbf_abstract_nav/src/abstract_navigation_server.cpp
@@ -45,8 +45,8 @@
 namespace mbf_abstract_nav
 {
 
-AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr)
-    : private_nh_("~"),
+AbstractNavigationServer::AbstractNavigationServer(const ros::NodeHandle& nh, const ros::NodeHandle& nhp, const TFPtr &tf_listener_ptr)
+    : private_nh_(nhp),
       planner_plugin_manager_("planners",
           boost::bind(&AbstractNavigationServer::loadPlannerPlugin, this, _1),
           boost::bind(&AbstractNavigationServer::initializePlannerPlugin, this, _1, _2)),
@@ -66,7 +66,7 @@ AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr)
       recovery_action_(name_action_recovery, robot_info_),
       move_base_action_(name_action_move_base, robot_info_, recovery_plugin_manager_.getLoadedNames())
 {
-  ros::NodeHandle nh;
+  ros::NodeHandle nodeHandle(nh);
 
   // oscillation timeout and distance
   double oscillation_timeout;
@@ -74,10 +74,10 @@ AbstractNavigationServer::AbstractNavigationServer(const TFPtr &tf_listener_ptr)
   oscillation_timeout_ = ros::Duration(oscillation_timeout);
   private_nh_.param("oscillation_distance", oscillation_distance_, 0.02);
 
-  goal_pub_ = nh.advertise<geometry_msgs::PoseStamped>("current_goal", 1);
+  goal_pub_ = nodeHandle.advertise<geometry_msgs::PoseStamped>("current_goal", 1);
 
   // init cmd_vel publisher for the robot velocity
-  vel_pub_ = nh.advertise<geometry_msgs::Twist>("cmd_vel", 1);
+  vel_pub_ = nodeHandle.advertise<geometry_msgs::Twist>("cmd_vel", 1);
 
   action_server_get_path_ptr_ = ActionServerGetPathPtr(
     new ActionServerGetPath(

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -84,9 +84,12 @@ public:
 
   /**
    * @brief Constructor
-   * @param tf_listener_ptr Shared pointer to a common TransformListener
+   * @param nh Public node handle.
+   * @param nhp Private node handle.
+   * @param tf_listener_ptr Shared pointer to a common TransformListener.
    */
-  CostmapNavigationServer(const TFPtr &tf_listener_ptr);
+  CostmapNavigationServer(const ros::NodeHandle &nh, const ros::NodeHandle &nhp,
+                          const TFPtr &tf_listener_ptr);
 
   /**
    * @brief Destructor

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -60,8 +60,10 @@ namespace mbf_costmap_nav
 {
 
 
-CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
-  AbstractNavigationServer(tf_listener_ptr),
+CostmapNavigationServer::CostmapNavigationServer(const ros::NodeHandle &nh,
+                                                 const ros::NodeHandle &nhp,
+                                                 const TFPtr &tf_listener_ptr) :
+  AbstractNavigationServer(nh, nhp, tf_listener_ptr),
   recovery_plugin_loader_("mbf_costmap_core", "mbf_costmap_core::CostmapRecovery"),
   nav_core_recovery_plugin_loader_("nav_core", "nav_core::RecoveryBehavior"),
   controller_plugin_loader_("mbf_costmap_core", "mbf_costmap_core::CostmapController"),

--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
   TFPtr tf_listener_ptr(new TF(ros::Duration(cache_time)));
   tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
 #endif
-  costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
+  costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(nh, private_nh, tf_listener_ptr);
   ros::spin();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Mainly to pass down remapping arguments to individual plugins