### PR TITLE
mbf_simple_nav: Pass node handles down to abstract navigation server.

### DIFF
--- a/mbf_simple_nav/include/mbf_simple_nav/simple_navigation_server.h
+++ b/mbf_simple_nav/include/mbf_simple_nav/simple_navigation_server.h
@@ -66,9 +66,11 @@ public:
 
   /**
    * @brief Constructor
+   * @param nh Node handle
+   * @param nhp Private node handle
    * @param tf_listener_ptr Shared pointer to a common TransformListener
    */
-  SimpleNavigationServer(const TFPtr &tf_listener_ptr);
+  SimpleNavigationServer(const ros::NodeHandle& nh, const ros::NodeHandle& nhp, const TFPtr &tf_listener_ptr);
 
   /**
    * @brief Destructor

--- a/mbf_simple_nav/src/simple_navigation_server.cpp
+++ b/mbf_simple_nav/src/simple_navigation_server.cpp
@@ -43,8 +43,8 @@
 namespace mbf_simple_nav
 {
 
-SimpleNavigationServer::SimpleNavigationServer(const TFPtr &tf_listener_ptr) :
-    mbf_abstract_nav::AbstractNavigationServer(tf_listener_ptr),
+SimpleNavigationServer::SimpleNavigationServer(const ros::NodeHandle& nh, const ros::NodeHandle& nhp, const TFPtr &tf_listener_ptr) :
+    mbf_abstract_nav::AbstractNavigationServer(nh, nhp, tf_listener_ptr),
     planner_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractPlanner"),
     controller_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractController"),
     recovery_plugin_loader_("mbf_abstract_core", "mbf_abstract_core::AbstractRecovery")

--- a/mbf_simple_nav/src/simple_server_node.cpp
+++ b/mbf_simple_nav/src/simple_server_node.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
 #endif 
   
   SimpleNavigationServerPtr controller_ptr(
-      new mbf_simple_nav::SimpleNavigationServer(tf_listener_ptr));
+      new mbf_simple_nav::SimpleNavigationServer(nh, private_nh, tf_listener_ptr));
 
   ros::spin();
   return EXIT_SUCCESS;


### PR DESCRIPTION
Fixes regression in #2 