### PR TITLE
Forward NodeHandles to controller, planner and recovery plugins

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -88,6 +88,7 @@ namespace mbf_abstract_nav
      * @param tf_listener_ptr Shared pointer to a common tf listener
      */
     AbstractControllerExecution(
+        const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
         const std::string name,
         const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
         const ros::Publisher& vel_pub,

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_navigation_server.h
@@ -298,6 +298,9 @@ typedef boost::shared_ptr<dynamic_reconfigure::Server<mbf_abstract_nav::MoveBase
      */
     virtual void reconfigure(mbf_abstract_nav::MoveBaseFlexConfig &config, uint32_t level);
 
+    //! Public node handle
+    ros::NodeHandle nh_;
+
     //! Private node handle
     ros::NodeHandle private_nh_;
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_planner_execution.h
@@ -84,7 +84,8 @@ namespace mbf_abstract_nav
      * @brief Constructor
      * @param condition Thread sleep condition variable, to wake up connected threads
      */
-    AbstractPlannerExecution(const std::string name,
+    AbstractPlannerExecution(const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
+                             const std::string name,
                              const mbf_abstract_core::AbstractPlanner::Ptr planner_ptr,
                              const MoveBaseFlexConfig &config,
                              boost::function<void()> setup_fn,

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_plugin_manager.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_plugin_manager.h
@@ -40,6 +40,7 @@
 #define MBF_ABSTRACT_NAV__ABSTRACT_PLUGIN_MANAGER_H_
 
 #include <boost/function.hpp>
+#include <ros/node_handle.h>
 
 namespace mbf_abstract_nav{
 
@@ -52,6 +53,7 @@ class AbstractPluginManager
   typedef boost::function<bool (const std::string& name, const typename PluginType::Ptr& plugin_ptr)> initPluginFunction;
 
   AbstractPluginManager(
+      const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
       const std::string param_name,
       const loadPluginFunction& loadPlugin,
       const initPluginFunction& initPlugin
@@ -74,6 +76,9 @@ class AbstractPluginManager
   const std::string param_name_;
   const loadPluginFunction loadPlugin_;
   const initPluginFunction initPlugin_;
+
+  //! Private node handle
+  ros::NodeHandle private_nh_;
 };
 } /* namespace mbf_abstract_nav */
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_recovery_execution.h
@@ -84,7 +84,8 @@ namespace mbf_abstract_nav
      * @param condition Thread sleep condition variable, to wake up connected threads
      * @param tf_listener_ptr Shared pointer to a common tf listener
      */
-    AbstractRecoveryExecution(const std::string name,
+    AbstractRecoveryExecution(const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
+                              const std::string name,
                               const mbf_abstract_core::AbstractRecovery::Ptr recovery_ptr,
                               const TFPtr &tf_listener_ptr,
                               const MoveBaseFlexConfig &config,

--- a/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/controller_action.h
@@ -56,7 +56,8 @@ class ControllerAction :
 
   typedef boost::shared_ptr<ControllerAction> Ptr;
 
-  ControllerAction(const std::string &name,
+  ControllerAction(const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
+                   const std::string &name,
                    const RobotInformation &robot_info);
 
   void start(
@@ -74,6 +75,9 @@ protected:
           uint32_t outcome, const std::string &message,
           const geometry_msgs::TwistStamped& current_twist);
 
+private:
+  //! Private node handle
+  ros::NodeHandle private_nh_;
 };
 }
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/impl/abstract_plugin_manager.tcc
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/impl/abstract_plugin_manager.tcc
@@ -46,21 +46,21 @@ namespace mbf_abstract_nav{
 
 template <typename PluginType>
 AbstractPluginManager<PluginType>::AbstractPluginManager(
+    const ros::NodeHandle &, const ros::NodeHandle &nhp,
     const std::string param_name,
     const loadPluginFunction& loadPlugin,
     const initPluginFunction& initPlugin
 )
-  : param_name_(param_name), loadPlugin_(loadPlugin), initPlugin_(initPlugin)
+  : param_name_(param_name), loadPlugin_(loadPlugin), initPlugin_(initPlugin),
+    private_nh_(nhp)
 {
 }
 
 template <typename PluginType>
 bool AbstractPluginManager<PluginType>::loadPlugins()
 {
-  ros::NodeHandle private_nh("~");
-
   XmlRpc::XmlRpcValue plugin_param_list;
-  if(!private_nh.getParam(param_name_, plugin_param_list))
+  if(!private_nh_.getParam(param_name_, plugin_param_list))
   {
     ROS_WARN_STREAM("No " << param_name_ << " plugins configured! - Use the param \"" << param_name_ << "\", "
         "which must be a list of tuples with a name and a type.");

--- a/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/move_base_action.h
@@ -66,7 +66,8 @@ class MoveBaseAction
 
   typedef actionlib::ActionServer<mbf_msgs::MoveBaseAction>::GoalHandle GoalHandle;
 
-  MoveBaseAction(const std::string &name, const RobotInformation &robot_info, const std::vector<std::string> &controllers);
+  MoveBaseAction(const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
+                 const std::string &name, const RobotInformation &robot_info, const std::vector<std::string> &controllers);
 
   ~MoveBaseAction();
 

--- a/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/planner_action.h
@@ -57,6 +57,7 @@ class PlannerAction : public AbstractAction<mbf_msgs::GetPathAction, AbstractPla
   typedef boost::shared_ptr<PlannerAction> Ptr;
 
   PlannerAction(
+      const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
       const std::string& name,
       const RobotInformation &robot_info
   );

--- a/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/recovery_action.h
@@ -56,7 +56,8 @@ class RecoveryAction : public AbstractAction<mbf_msgs::RecoveryAction, AbstractR
 
   typedef boost::shared_ptr<RecoveryAction> Ptr;
 
-  RecoveryAction(const std::string& name, const RobotInformation &robot_info);
+  RecoveryAction(const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
+                 const std::string& name, const RobotInformation &robot_info);
 
   void run(GoalHandle &goal_handle, AbstractRecoveryExecution &execution);
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -47,6 +47,7 @@ namespace mbf_abstract_nav
   const double AbstractControllerExecution::DEFAULT_CONTROLLER_FREQUENCY = 100.0; // 100 Hz
 
   AbstractControllerExecution::AbstractControllerExecution(
+      const ros::NodeHandle&, const ros::NodeHandle& private_nh,
       const std::string name,
       const mbf_abstract_core::AbstractController::Ptr& controller_ptr,
       const ros::Publisher& vel_pub,
@@ -62,9 +63,6 @@ namespace mbf_abstract_nav
       vel_pub_(vel_pub), current_goal_pub_(goal_pub),
       state_(INITIALIZED), moving_(false)
   {
-    ros::NodeHandle nh;
-    ros::NodeHandle private_nh("~");
-
     // non-dynamically reconfigurable parameters
     private_nh.param("robot_frame", robot_frame_, std::string("base_link"));
     private_nh.param("map_frame", global_frame_, std::string("map"));

--- a/mbf_abstract_nav/src/abstract_planner_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_planner_execution.cpp
@@ -44,7 +44,8 @@ namespace mbf_abstract_nav
 {
 
 
-  AbstractPlannerExecution::AbstractPlannerExecution(const std::string name,
+  AbstractPlannerExecution::AbstractPlannerExecution(const ros::NodeHandle&, const ros::NodeHandle& private_nh,
+                                                     const std::string name,
                                                      const mbf_abstract_core::AbstractPlanner::Ptr planner_ptr,
                                                      const MoveBaseFlexConfig &config,
                                                      boost::function<void()> setup_fn,
@@ -54,8 +55,6 @@ namespace mbf_abstract_nav
       has_new_goal_(false), has_new_start_(false),
       planning_(false), state_(INITIALIZED)
   {
-    ros::NodeHandle private_nh("~");
-
     // non-dynamically reconfigurable parameters
     private_nh.param("robot_frame", robot_frame_, std::string("base_footprint"));
     private_nh.param("map_frame", global_frame_, std::string("map"));

--- a/mbf_abstract_nav/src/abstract_recovery_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_recovery_execution.cpp
@@ -48,6 +48,7 @@ namespace mbf_abstract_nav
 
 
   AbstractRecoveryExecution::AbstractRecoveryExecution(
+      const ros::NodeHandle& /*nh*/, const ros::NodeHandle& /*nhp*/,
       const std::string name,
       mbf_abstract_core::AbstractRecovery::Ptr recovery_ptr,
       const TFPtr &tf_listener_ptr,

--- a/mbf_abstract_nav/src/controller_action.cpp
+++ b/mbf_abstract_nav/src/controller_action.cpp
@@ -44,9 +44,11 @@ namespace mbf_abstract_nav{
 
 
 ControllerAction::ControllerAction(
+    const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
     const std::string &action_name,
     const RobotInformation &robot_info)
-    : AbstractAction(action_name, robot_info, boost::bind(&mbf_abstract_nav::ControllerAction::run, this, _1, _2))
+    : AbstractAction(action_name, robot_info, boost::bind(&mbf_abstract_nav::ControllerAction::run, this, _1, _2)),
+      private_nh_(nhp)
 {
 }
 
@@ -106,14 +108,12 @@ void ControllerAction::run(GoalHandle &goal_handle, AbstractControllerExecution 
 {
   ROS_DEBUG_STREAM_NAMED(name_, "Start action "  << name_);
 
-  ros::NodeHandle private_nh("~");
-
   double oscillation_timeout_tmp;
-  private_nh.param("oscillation_timeout", oscillation_timeout_tmp, 0.0);
+  private_nh_.param("oscillation_timeout", oscillation_timeout_tmp, 0.0);
   ros::Duration oscillation_timeout(oscillation_timeout_tmp);
 
   double oscillation_distance;
-  private_nh.param("oscillation_distance", oscillation_distance, 0.03);
+  private_nh_.param("oscillation_distance", oscillation_distance, 0.03);
 
   mbf_msgs::ExePathResult result;
   mbf_msgs::ExePathFeedback feedback;

--- a/mbf_abstract_nav/src/move_base_action.cpp
+++ b/mbf_abstract_nav/src/move_base_action.cpp
@@ -46,12 +46,13 @@
 namespace mbf_abstract_nav
 {
 
-MoveBaseAction::MoveBaseAction(const std::string &name,
+MoveBaseAction::MoveBaseAction(const ros::NodeHandle&, const ros::NodeHandle& nhp,
+                               const std::string &name,
                                const RobotInformation &robot_info,
                                const std::vector<std::string> &behaviors)
   :  oscillation_timeout_(0),
      oscillation_distance_(0),
-     name_(name), robot_info_(robot_info), private_nh_("~"),
+     name_(name), robot_info_(robot_info), private_nh_(nhp),
      action_client_exe_path_(private_nh_, "exe_path"),
      action_client_get_path_(private_nh_, "get_path"),
      action_client_recovery_(private_nh_, "recovery"),

--- a/mbf_abstract_nav/src/planner_action.cpp
+++ b/mbf_abstract_nav/src/planner_action.cpp
@@ -44,12 +44,13 @@
 namespace mbf_abstract_nav{
 
 PlannerAction::PlannerAction(
+    const ros::NodeHandle& _nh, const ros::NodeHandle&,
     const std::string &name,
     const RobotInformation &robot_info)
   : AbstractAction(name, robot_info, boost::bind(&mbf_abstract_nav::PlannerAction::run, this, _1, _2)), path_seq_count_(0)
 {
 
-  ros::NodeHandle nh;
+  ros::NodeHandle nh(_nh);
   // informative topics: current goal and global path
   path_pub_ = nh.advertise<nav_msgs::Path>("global_path", 1);
   current_goal_pub_ = nh.advertise<geometry_msgs::PoseStamped>("current_goal", 1);

--- a/mbf_abstract_nav/src/recovery_action.cpp
+++ b/mbf_abstract_nav/src/recovery_action.cpp
@@ -42,7 +42,9 @@
 
 namespace mbf_abstract_nav{
 
-RecoveryAction::RecoveryAction(const std::string &name, const RobotInformation &robot_info)
+RecoveryAction::RecoveryAction(
+    const ros::NodeHandle&, const ros::NodeHandle&,
+    const std::string &name, const RobotInformation &robot_info)
   : AbstractAction(name, robot_info, boost::bind(&mbf_abstract_nav::RecoveryAction::run, this, _1, _2)){}
 
 void RecoveryAction::run(GoalHandle &goal_handle, AbstractRecoveryExecution &execution)

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -68,6 +68,7 @@ public:
    * @param costmap_ptr Shared pointer to the costmap.
    */
   CostmapControllerExecution(
+      const ros::NodeHandle& nh, const ros::NodeHandle& private_nh,
       const std::string name,
       const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
       const ros::Publisher& vel_pub,

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_planner_execution.h
@@ -65,6 +65,7 @@ public:
    * @param costmap Shared pointer to the costmap.
    */
   CostmapPlannerExecution(
+      const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
       const std::string name,
       const mbf_costmap_core::CostmapPlanner::Ptr &planner_ptr,
       CostmapPtr &costmap,

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_recovery_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_recovery_execution.h
@@ -69,6 +69,7 @@ public:
    * @param local_costmap Shared pointer to the local costmap.
    */
   CostmapRecoveryExecution(
+      const ros::NodeHandle& nh, const ros::NodeHandle& nhp,
       const std::string name,
       const mbf_costmap_core::CostmapRecovery::Ptr &recovery_ptr,
       const TFPtr &tf_listener_ptr,

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -43,6 +43,7 @@ namespace mbf_costmap_nav
 {
 
 CostmapControllerExecution::CostmapControllerExecution(
+    const ros::NodeHandle& nh, const ros::NodeHandle& private_nh,
     const std::string name,
     const mbf_costmap_core::CostmapController::Ptr &controller_ptr,
     const ros::Publisher& vel_pub,
@@ -52,11 +53,10 @@ CostmapControllerExecution::CostmapControllerExecution(
     const MoveBaseFlexConfig &config,
     boost::function<void()> setup_fn,
     boost::function<void()> cleanup_fn)
-      : AbstractControllerExecution(name, controller_ptr, vel_pub, goal_pub, tf_listener_ptr,
+      : AbstractControllerExecution(nh, private_nh, name, controller_ptr, vel_pub, goal_pub, tf_listener_ptr,
           toAbstract(config), setup_fn, cleanup_fn),
         costmap_ptr_(costmap_ptr)
 {
-  ros::NodeHandle private_nh("~");
   private_nh.param("controller_lock_costmap", lock_costmap_, true);
 }
 

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -117,7 +117,7 @@ mbf_abstract_nav::AbstractPlannerExecution::Ptr CostmapNavigationServer::newPlan
     const mbf_abstract_core::AbstractPlanner::Ptr plugin_ptr)
 {
   return boost::make_shared<mbf_costmap_nav::CostmapPlannerExecution>(
-      name,
+      nh_, private_nh_, name,
       boost::static_pointer_cast<mbf_costmap_core::CostmapPlanner>(plugin_ptr),
       boost::ref(global_costmap_ptr_),
       last_config_,
@@ -129,31 +129,52 @@ mbf_abstract_nav::AbstractControllerExecution::Ptr CostmapNavigationServer::newC
     const std::string name,
     const mbf_abstract_core::AbstractController::Ptr plugin_ptr)
 {
-  return boost::make_shared<mbf_costmap_nav::CostmapControllerExecution>(
-      name,
-      boost::static_pointer_cast<mbf_costmap_core::CostmapController>(plugin_ptr),
-      vel_pub_,
-      goal_pub_,
-      tf_listener_ptr_,
-      boost::ref(local_costmap_ptr_),
-      last_config_,
-      boost::bind(&CostmapNavigationServer::checkActivateCostmaps, this),
-      boost::bind(&CostmapNavigationServer::checkDeactivateCostmaps, this));
+//  return boost::make_shared<mbf_costmap_nav::CostmapControllerExecution>(
+//      nh_, private_nh_, name,
+//      boost::static_pointer_cast<mbf_costmap_core::CostmapController>(plugin_ptr),
+//      vel_pub_,
+//      goal_pub_,
+//      tf_listener_ptr_,
+//      boost::ref(local_costmap_ptr_),
+//      last_config_,
+//      boost::bind(&CostmapNavigationServer::checkActivateCostmaps, this),
+//      boost::bind(&CostmapNavigationServer::checkDeactivateCostmaps, this));
+  return mbf_abstract_nav::AbstractControllerExecution::Ptr(
+      new mbf_costmap_nav::CostmapControllerExecution(
+        nh_, private_nh_, name,
+        boost::static_pointer_cast<mbf_costmap_core::CostmapController>(plugin_ptr),
+        vel_pub_,
+        goal_pub_,
+        tf_listener_ptr_,
+        boost::ref(local_costmap_ptr_),
+        last_config_,
+        boost::bind(&CostmapNavigationServer::checkActivateCostmaps, this),
+        boost::bind(&CostmapNavigationServer::checkDeactivateCostmaps, this)));
 }
 
 mbf_abstract_nav::AbstractRecoveryExecution::Ptr CostmapNavigationServer::newRecoveryExecution(
     const std::string name,
     const mbf_abstract_core::AbstractRecovery::Ptr plugin_ptr)
 {
-  return boost::make_shared<mbf_costmap_nav::CostmapRecoveryExecution>(
-      name,
-      boost::static_pointer_cast<mbf_costmap_core::CostmapRecovery>(plugin_ptr),
-      tf_listener_ptr_,
-      boost::ref(global_costmap_ptr_),
-      boost::ref(local_costmap_ptr_),
-      last_config_,
-      boost::bind(&CostmapNavigationServer::checkActivateCostmaps, this),
-      boost::bind(&CostmapNavigationServer::checkDeactivateCostmaps, this));
+//  return boost::make_shared<mbf_costmap_nav::CostmapRecoveryExecution>(
+//      nh_, private_nh_, name,
+//      boost::static_pointer_cast<mbf_costmap_core::CostmapRecovery>(plugin_ptr),
+//      tf_listener_ptr_,
+//      boost::ref(global_costmap_ptr_),
+//      boost::ref(local_costmap_ptr_),
+//      last_config_,
+//      boost::bind(&CostmapNavigationServer::checkActivateCostmaps, this),
+//      boost::bind(&CostmapNavigationServer::checkDeactivateCostmaps, this));
+  return mbf_abstract_nav::AbstractRecoveryExecution::Ptr(
+      new mbf_costmap_nav::CostmapRecoveryExecution(
+        nh_, private_nh_, name,
+        boost::static_pointer_cast<mbf_costmap_core::CostmapRecovery>(plugin_ptr),
+        tf_listener_ptr_,
+        boost::ref(global_costmap_ptr_),
+        boost::ref(local_costmap_ptr_),
+        last_config_,
+        boost::bind(&CostmapNavigationServer::checkActivateCostmaps, this),
+        boost::bind(&CostmapNavigationServer::checkDeactivateCostmaps, this)));
 }
 
 mbf_abstract_core::AbstractPlanner::Ptr CostmapNavigationServer::loadPlannerPlugin(const std::string& planner_type)

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_planner_execution.cpp
@@ -45,16 +45,16 @@ namespace mbf_costmap_nav
 {
 
 CostmapPlannerExecution::CostmapPlannerExecution(
+    const ros::NodeHandle& nh, const ros::NodeHandle& private_nh,
     const std::string name,
     const mbf_costmap_core::CostmapPlanner::Ptr &planner_ptr,
     CostmapPtr &costmap_ptr,
     const MoveBaseFlexConfig &config,
     boost::function<void()> setup_fn,
     boost::function<void()> cleanup_fn)
-      : AbstractPlannerExecution(name, planner_ptr, toAbstract(config), setup_fn, cleanup_fn),
+      : AbstractPlannerExecution(nh, private_nh, name, planner_ptr, toAbstract(config), setup_fn, cleanup_fn),
         costmap_ptr_(costmap_ptr)
 {
-  ros::NodeHandle private_nh("~");
   private_nh.param("planner_lock_costmap", lock_costmap_, true);
 }
 

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_recovery_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_recovery_execution.cpp
@@ -45,6 +45,7 @@ namespace mbf_costmap_nav
 {
 
 CostmapRecoveryExecution::CostmapRecoveryExecution(
+    const ros::NodeHandle& nh, const ros::NodeHandle& private_nh,
     const std::string name,
     const mbf_costmap_core::CostmapRecovery::Ptr &recovery_ptr,
     const TFPtr &tf_listener_ptr,
@@ -52,7 +53,7 @@ CostmapRecoveryExecution::CostmapRecoveryExecution(
     const MoveBaseFlexConfig &config,
     boost::function<void()> setup_fn,
     boost::function<void()> cleanup_fn)
-      : AbstractRecoveryExecution(name, recovery_ptr, tf_listener_ptr, toAbstract(config), setup_fn, cleanup_fn),
+      : AbstractRecoveryExecution(nh, private_nh, name, recovery_ptr, tf_listener_ptr, toAbstract(config), setup_fn, cleanup_fn),
         global_costmap_(global_costmap), local_costmap_(local_costmap)
 {
 }


### PR DESCRIPTION
Needed to fix parameterization and remappings if the node name does not match the namespace of the NodeHandle passed in the contructor of `AbstractNavigationServer` or `CostmapNavigationServer`.